### PR TITLE
Adicionando Arquitetura orientadas a eventos com RABBITMQ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,20 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.cloud:spring-cloud-function-context'
+//	implementation 'org.springframework.boot:spring-boot-starter'
+//	implementation 'org.springframework.cloud:spring-cloud-function-context'
+//	essas duas dependencia acima são incluidas automaticamente na dependencia stream-binder-rabbit
+	implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'io.projectreactor:reactor-test'
+
+	testImplementation 'org.springframework.cloud:spring-cloud-stream'
+	testImplementation 'org.springframework.cloud:spring-cloud-stream-test-binder'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:rabbitmq'
+
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/polarbookshop/dispatcherservice/DispatchingFunctions.java
+++ b/src/main/java/com/polarbookshop/dispatcherservice/DispatchingFunctions.java
@@ -1,13 +1,13 @@
 package com.polarbookshop.dispatcherservice;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import reactor.core.publisher.Flux;
-
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DispatchingFunctions {
@@ -17,17 +17,18 @@ public class DispatchingFunctions {
     @Bean
     public Function<OrderAcceptedMessage, Long> pack() {
         return orderAcceptedMessage -> {
-            log.info("The order with id {} is packed.", orderAcceptedMessage.id());
-            return orderAcceptedMessage.id();
+            log.info("The order with id {} is packed.", orderAcceptedMessage.orderId());
+            return orderAcceptedMessage.orderId();
         };
     }
-
 
     @Bean
     public Function<Flux<Long>, Flux<OrderDispatchedMessage>> label() {
         return orderFlux -> orderFlux.map(orderId -> {
-            log.info("O pedido com id {} está rotulado.", orderId);
+            log.info("The order with id {} is labeled.", orderId);
             return new OrderDispatchedMessage(orderId);
         });
     }
+
 }
+

--- a/src/main/java/com/polarbookshop/dispatcherservice/OrderAcceptedMessage.java
+++ b/src/main/java/com/polarbookshop/dispatcherservice/OrderAcceptedMessage.java
@@ -1,6 +1,9 @@
 package com.polarbookshop.dispatcherservice;
 
-public record OrderAcceptedMessage(
-        Long id
-) {
+import java.io.Serializable;
+
+public record OrderAcceptedMessage (
+        Long orderId
+) implements Serializable {
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,4 +5,17 @@ spring:
     name: dispatcher-service
   cloud:
     function:
-      definition: pack | label
+      definition: pack|label
+    stream:
+      bindings:
+        packlabel-in-0:
+          destination: order-accepted
+          group: ${spring.application.name}
+        packlabel-out-0:
+          destination: order-dispatched
+  rabbitmq:
+    host: localhost
+    port: 5672
+    username: user
+    password: password
+    connection-timeout: 5s

--- a/src/test/java/com/polarbookshop/dispatcherservice/FunctionsStreamIntegrationTests.java
+++ b/src/test/java/com/polarbookshop/dispatcherservice/FunctionsStreamIntegrationTests.java
@@ -1,0 +1,49 @@
+package com.polarbookshop.dispatcherservice;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.stream.binder.test.InputDestination;
+import org.springframework.cloud.stream.binder.test.OutputDestination;
+import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+@Import(TestChannelBinderConfiguration.class)
+public class FunctionsStreamIntegrationTests {
+
+    @Autowired
+    private InputDestination inputDestination;
+
+    @Autowired
+    private OutputDestination outputDestination;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void whenOrderAcceptedThenDispatched() throws IOException {
+        long orderId = 121;
+
+        Message<OrderAcceptedMessage> inputMessage = MessageBuilder
+                .withPayload(new OrderAcceptedMessage(orderId)).build();
+
+        Message<OrderDispatchedMessage> expectedMessage = MessageBuilder
+                .withPayload(new OrderDispatchedMessage(orderId)).build();
+
+        this.inputDestination.send(inputMessage);
+        assertThat(objectMapper.readValue(outputDestination.receive().getPayload(),
+                OrderDispatchedMessage.class))
+                .isEqualTo(expectedMessage.getPayload());
+    }
+
+}


### PR DESCRIPTION
Adicionando Arquitetura orientadas a eventos com RABBITMQ, para empacotar e rotular e despachar o pedido para a exchage e queue order-dispatched para ser consumido pelo aplicativo order-service ou quem tiver interessado.