### PR TITLE
Adicionando Spring boot Actuator e OpenTelemetry javaagent, para moni…

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -3,7 +3,7 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: polar-libraries/dispatcher-service
+  IMAGE_NAME: polarbookshop/dispatcher-service
   VERSION: latest
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ repositories {
 }
 ext {
 	set('springCloudVersion', "2024.0.1")
+	set('otelVersion', "1.33.3")
 }
 
 dependencies {
@@ -25,6 +26,12 @@ dependencies {
 //	implementation 'org.springframework.cloud:spring-cloud-function-context'
 //	essas duas dependencia acima são incluidas automaticamente na dependencia stream-binder-rabbit
 	implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	runtimeOnly "io.opentelemetry.javaagent:opentelemetry-javaagent:${otelVersion}"
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'io.projectreactor:reactor-test'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: dispatcher-service
+      annotations:
+        prometheus.io/scrap: "true"
+        prometheus.io/path: /actuator/prometheus
+        prometheus.io/port: "9003"
     spec:
       containers:
         - name: dispatcher-service
@@ -29,3 +33,15 @@ spec:
               value: http://config-service
             - name: SPRING_RABBITMQ_HOST
               value: polar-rabbitmq
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9001
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 9001
+            initialDelaySeconds: 5
+            periodSeconds: 15

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,22 @@ spring:
     username: user
     password: password
     connection-timeout: 5s
+
+logging:
+  pattern:
+    level: "%5p [${spring.application.name},%X{trace_id},%X{span_id}]"
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}

--- a/src/test/java/com/polarbookshop/dispatcherservice/DispatchingFunctionsIntegrationTests.java
+++ b/src/test/java/com/polarbookshop/dispatcherservice/DispatchingFunctionsIntegrationTests.java
@@ -9,6 +9,8 @@ import reactor.test.StepVerifier;
 
 import java.util.function.Function;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 @FunctionalSpringBootTest
 public class DispatchingFunctionsIntegrationTests {
 
@@ -16,16 +18,22 @@ public class DispatchingFunctionsIntegrationTests {
     private FunctionCatalog catalog;
 
     @Test
-    void packAndLabelOrder() {
-
-        Function<OrderAcceptedMessage, Flux<OrderDispatchedMessage>> packAndLabel =
-                catalog.lookup(Function.class, "pack|label");
-
+    void packOrder() {
+        Function<OrderAcceptedMessage, Long> pack = catalog.lookup(Function.class, "pack");
         long orderId = 121;
-        StepVerifier.create(packAndLabel.apply(new OrderAcceptedMessage(orderId)))
-                .expectNextMatches(
-                        dispatchOrder -> dispatchOrder
-                                .equals(new OrderDispatchedMessage(orderId)))
+        assertThat(pack.apply(new OrderAcceptedMessage(orderId))).isEqualTo(orderId);
+    }
+
+    @Test
+    void labelOrder() {
+        Function<Flux<Long>, Flux<OrderDispatchedMessage>> label = catalog.lookup(Function.class, "label");
+        Flux<Long> orderId = Flux.just(121L);
+
+        StepVerifier.create(label.apply(orderId))
+                .expectNextMatches(dispatchedOrder ->
+                        dispatchedOrder.equals(new OrderDispatchedMessage(121L)))
                 .verifyComplete();
     }
+
+
 }


### PR DESCRIPTION
Adicionando Spring boot Actuator e OpenTelemetry javaagent, para monitoramento de Logs de eventos, metricas e telemetrias dos aplicativos, para obter uma melhor observabilidade e rastreamento de infraestrutura e funções do aplicativo desenvolvido. Utilizando a plataforma de observabilidade Grafana para gerenciar os sevirçoes de apoio, que são prometheus, Fluent-bit: para coletar os logs de eventos. Loki: para amarzena os eventos de logs coletado pelo fluent-bit. Tempo+OpenTelemetry para gerar arquivos de logs dentro do LOKI, mostrando o fluxo realizado para a requisição HTTP da aplicação e o fluxo realizado dentro dessa aplicação. Unica maneira até o momento de realizar monitoramento de aplicativos distribuidos.