### PR TITLE
Implementado o Kustomize para gerenciar os manifestos do Kubernetes

### DIFF
--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -43,10 +43,11 @@ jobs:
       - name: Install tools
         uses: alexellis/arkade-get@master
         with:
+          kustomize: latest
           kubeconform: latest
       - name: Validate Kubernetes manifests
         run: |
-          kubeconform --strict k8s
+          kustomize build k8s | kubeconform --strict -
   package:
     name: Package and Publish
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -5,6 +5,6 @@ custom_build(
 
 )
 
-k8s_yaml(['k8s/deployment.yml', 'k8s/service.yml'])
+k8s_yaml(kustomize('k8s'))
 
 k8s_resource('dispatcher-service', port_forwards=['9003'])

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-stream-binder-rabbit'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+
 
 	runtimeOnly "io.opentelemetry.javaagent:opentelemetry-javaagent:${otelVersion}"
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
@@ -48,6 +50,10 @@ dependencyManagement {
 	imports {
 		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
 	}
+}
+
+springBoot {
+	buildInfo()
 }
 
 bootBuildImage {

--- a/k8s/application.yml
+++ b/k8s/application.yml
@@ -1,0 +1,3 @@
+spring:
+  rabbitmq:
+    host: polar-rabbitmq

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: dispatcher-service
       annotations:
-        prometheus.io/scrap: "true"
+        prometheus.io/scrape: "true"
         prometheus.io/path: /actuator/prometheus
         prometheus.io/port: "9003"
     spec:
@@ -28,11 +28,6 @@ spec:
                 command: ["sh", "-c", "sleep 5"]
           ports:
             - containerPort: 9003
-          env:
-            - name: SPRING_CLOUD_CONFIG
-              value: http://config-service
-            - name: SPRING_RABBITMQ_HOST
-              value: polar-rabbitmq
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
@@ -45,3 +40,10 @@ spec:
               port: 9001
             initialDelaySeconds: 5
             periodSeconds: 15
+          volumeMounts:
+            - name: dispatcher-service-volume
+              mountPath: /workspace/config
+      volumes:
+        - name: dispatcher-service-volume
+          configMap:
+            name: dispatcher-config

--- a/k8s/kustomization.yml
+++ b/k8s/kustomization.yml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yml
+  - service.yml
+
+configMapGenerator:
+  - name: dispatcher-config
+    files:
+      - application.yml
+    options:
+      labels:
+        app: dispatcher-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,20 @@ server:
 spring:
   application:
     name: dispatcher-service
+  config:
+    import: "" # When using Config Service, add "optional:configserver:"
   cloud:
+    config:
+      enabled: false # When using Config Service, set to true
+      uri: http://localhost:8888
+      request-connect-timeout: 5000 # 5s
+      request-read-timeout: 5000 # 5s
+      fail-fast: false # In production, set to true
+      retry:
+        max-attempts: 6
+        initial-interval: 1000 # 1s
+        max-interval: 2000 # 2s
+        multiplier: 1.1
     function:
       definition: pack|label
     stream:
@@ -24,17 +37,27 @@ logging:
   pattern:
     level: "%5p [${spring.application.name},%X{trace_id},%X{span_id}]"
 
+info:
+  system: Polar Bookshop
+
 management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: bindings, configprops, env, functions, health, heapdump, info, loggers, mappings, prometheus
   endpoint:
     health:
       show-details: always
       show-components: always
       probes:
         enabled: true
+  info:
+    env:
+      enabled: true
+    java:
+      enabled: true
+    os:
+      enabled: true
   metrics:
     tags:
       application: ${spring.application.name}


### PR DESCRIPTION
Implementado o Kustomize para gerenciar os manifestos do Kubernetes como uma única entidade através do arquivo kustomization.yml, tornando a gestão mais limpa e otimizada.

Também foi adicionado um ConfigMapGenerator que carrega um arquivo de configuração application.yml. Dessa forma, sempre que houver alterações nesse arquivo, o Kustomize aplica automaticamente as novas configurações e reinicia os pods que o utilizam.

Diferente do ConfigMap criado manualmente, que não refletia alterações mesmo após o restart dos pods, essa abordagem garante que as atualizações sejam aplicadas corretamente de forma automática e declarativa.