### PR TITLE
O estágio de commit vai do commit do código até um release candidate, que então passa pelo estágio de aceitação

### DIFF
--- a/.github/workflows/acceptance-stage.yml
+++ b/.github/workflows/acceptance-stage.yml
@@ -1,0 +1,50 @@
+name: Acceptance Stage
+on:
+  workflow_run:
+    workflows: ['Commit Stage']
+    types: [completed]
+    branches: main
+concurrency: acceptance
+
+env:
+  OWNER: polar-libraries
+  REGISTRY: ghcr.io
+  APP_REPO: dispatcher-service
+  DEPLOY_REPO: polar-deployment
+  VERSION: ${{ github.sha }}
+
+jobs:
+  functional:
+    name: Functional Acceptance Tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Running functional acceptance tests"
+  performance:
+    name: Performance Tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Running performance tests"
+  security:
+    name: Security Tests
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Running security tests"
+  deliver:
+    name: Deliver release candidate to production
+    needs: [ functional, performance, security ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deliver application to production
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: ${{ env.OWNER }}/${{ env.DEPLOY_REPO }}
+          event-type: app_delivery
+          client-payload: '{
+            "app_image": "${{ env.REGISTRY }}/${{ env.OWNER }}/${{ env.APP_REPO }}",
+            "app_name": "${{ env.APP_REPO }}",
+            "app_version": "${{ env.VERSION }}"
+          }'

--- a/.github/workflows/commit-stage.yml
+++ b/.github/workflows/commit-stage.yml
@@ -3,8 +3,8 @@ on: push
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: polarbookshop/dispatcher-service
-  VERSION: latest
+  IMAGE_NAME: polar-libraries/dispatcher-service
+  VERSION: ${{ github.sha }}
 
 jobs:
   build:
@@ -91,3 +91,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish container image
         run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+      - name: Publish container image (latest)
+        run: |
+          docker tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
Configurando as imagens para ser lançada com um release candidate com identificador sha e uma com uma tag latest para desenvolvimento local. Com identificação exclusiva ela pode ser encaminhado para o estagio de aceitação. Nessa versão foi adicionado o acceptance-stage.yml. O estágio de commit vai do commit do código até um release candidate, que então passa pelo estágio de aceitação. Se passar em todos os testes, estará pronto para produção.
